### PR TITLE
Updated site plugin to 3.3  - this was causing builds to fail; see

### DIFF
--- a/redquerybuilder-dist/pom.xml
+++ b/redquerybuilder-dist/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
             	<groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.3</version>
                 <configuration>
                 	<reportPlugins>
 			<plugin>


### PR DESCRIPTION
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound